### PR TITLE
Added biggest key index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "./Cargo.toml",
         "./Cargo.toml",
         "./Cargo.toml",
+        "./Cargo.toml",
         "./Cargo.toml"
     ]
 }

--- a/src/block/block.rs
+++ b/src/block/block.rs
@@ -50,7 +50,7 @@
 
 use tokio::{
     fs::File,
-    io::{self, AsyncSeekExt, AsyncWriteExt},
+    io::{self, AsyncWriteExt},
 };
 
 use err::StorageEngineError::*;
@@ -59,7 +59,7 @@ use crate::{
     consts::{SIZE_OF_U32, SIZE_OF_U64, SIZE_OF_U8},
     err::{self, StorageEngineError},
 };
-const BLOCK_SIZE: usize = 8 * 1024; // 4KB
+const BLOCK_SIZE: usize = 64 * 1024; // 4KB
 
 #[derive(Debug, Clone)]
 pub struct Block {
@@ -129,7 +129,7 @@ impl Block {
     }
 
     pub async fn write_to_file(&self, file: &mut File) -> Result<(), StorageEngineError> {
-        for  entry in &self.data {
+        for entry in &self.data {
             let entry_len = entry.key.len() + SIZE_OF_U32 + SIZE_OF_U32 + SIZE_OF_U64 + SIZE_OF_U8;
             let mut entry_vec = Vec::with_capacity(entry_len);
 

--- a/src/compaction/bucket_coordinator.rs
+++ b/src/compaction/bucket_coordinator.rs
@@ -28,6 +28,7 @@ use StorageEngineError::*;
 pub trait IndexWithSizeInBytes {
     fn get_index(&self) -> Arc<SkipMap<Vec<u8>, (usize, u64, bool)>>; // usize for value offset, u64 to store entry creation date in milliseconds
     fn size(&self) -> usize;
+    fn find_biggest_key_from_table(&self) -> Result<Vec<u8>, StorageEngineError>;
 }
 
 impl Bucket {

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -2,7 +2,7 @@ use crate::storage_engine::SizeUnit;
 
 pub const GC_THREAD_COUNT: u32 = 5;
 
-pub const DEFAULT_MEMTABLE_CAPACITY: usize = SizeUnit::Kilobytes.to_bytes(30);
+pub const DEFAULT_MEMTABLE_CAPACITY: usize = SizeUnit::Megabytes.to_bytes(1);
 
 pub const DEFAULT_FALSE_POSITIVE_RATE: f64 = 1e-200;
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -149,11 +149,17 @@ pub enum StorageEngineError {
     #[error("Index file write error")]
     IndexFileWriteError(#[source] io::Error),
 
-     /// Error while reading from index file
-     #[error("Index file read error")]
-     IndexFileReadError(#[source] io::Error),
+    /// Error while reading from index file
+    #[error("Index file read error")]
+    IndexFileReadError(#[source] io::Error),
 
     /// Error while flushing write to disk for index file
     #[error("Index file flush error")]
     IndexFileFlushError(#[source] io::Error),
+
+    #[error("Error finding biggest key in memtable (None was returned)")]
+    BiggestKeyIndexError,
+
+    #[error("All bloom filters return false for all sstables")]
+    KeyNotFoundByAnyBloomFilterError,
 }

--- a/src/key_offseter/key_offseter.rs
+++ b/src/key_offseter/key_offseter.rs
@@ -1,0 +1,33 @@
+use std::{cmp::Ordering, collections::HashMap, path::PathBuf};
+
+#[derive(Clone, Debug)]
+pub struct TableBiggestKeys {
+    pub sstables: HashMap<PathBuf, Vec<u8>>,
+}
+impl TableBiggestKeys {
+    pub fn new() -> Self {
+        Self {
+            sstables: HashMap::new(),
+        }
+    }
+
+    pub fn set(&mut self, sst_path: PathBuf, biggest_key: Vec<u8>) -> bool {
+        self.sstables.insert(sst_path, biggest_key).is_some()
+    }
+
+    pub fn remove(&mut self, sst_path: PathBuf) -> bool {
+        self.sstables.remove(&sst_path).is_some()
+    }
+
+    // Returns SSTables whose last key is greater than the supplied key parameter
+    pub fn filter_sstables_by_biggest_key(&self, key: &Vec<u8>) -> Vec<&PathBuf> {
+        self.sstables
+            .iter()
+            .filter(|(_, key_prefix)| {
+                key_prefix.as_slice().cmp(key) == Ordering::Greater
+                    || key_prefix.as_slice().cmp(key) == Ordering::Equal
+            })
+            .map(|(path, _)| return path)
+            .collect()
+    }
+}

--- a/src/key_offseter/mod.rs
+++ b/src/key_offseter/mod.rs
@@ -1,0 +1,2 @@
+mod key_offseter;
+pub use key_offseter::TableBiggestKeys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,4 @@ pub mod value_log;
 pub mod block;
 pub mod garbage_collector;
 pub mod sparse_index;
+pub mod key_offseter;

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -44,6 +44,9 @@ impl IndexWithSizeInBytes for SSTable {
     fn size(&self) -> usize {
         self.size
     }
+    fn find_biggest_key_from_table(&self) -> Result<Vec<u8>, StorageEngineError>{
+        self.find_biggest_key()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -134,7 +137,14 @@ impl SSTable {
             created_at: created_at.timestamp_millis() as u64,
         }
     }
-
+    // Find the biggest element in the skip list
+    pub fn find_biggest_key(&self) -> Result<Vec<u8>, StorageEngineError> {
+        let largest_entry = self.index.iter().next_back();
+        match largest_entry {
+            Some(e) => return Ok(e.key().to_vec()),
+            None => Err(BiggestKeyIndexError),
+        }
+    }
     pub(crate) async fn write_to_file(&self) -> Result<(), StorageEngineError> {
         // Open the file in write mode with the append flag.
         let data_file_path = &self.data_file_path;


### PR DESCRIPTION
Changes include:

- Adding the biggest key index which stores the last key in each sstable to speed up retrieval time especially when numerous chunks of sstables might not include the searched key(s)

- This also helps narrow down the number of Bloom Filters we need to search therefore reducing read time. 

- Performed some load testing to see the improvement in single and concurrent queries

- Block Size temporarily changed to 64KB for testing 

- Memtable Size temporarily changed to  1MB 