### PR TITLE
Ft/rw lock access

### DIFF
--- a/src/flusher/flusher.rs
+++ b/src/flusher/flusher.rs
@@ -5,11 +5,13 @@ use crate::{
     err::StorageEngineError,
     key_offseter::TableBiggestKeys,
     memtable::InMemoryTable,
+    storage_engine::ExcRwAcc,
 };
+use indexmap::IndexMap;
 use std::sync::Arc;
+use std::{borrow::Borrow, hash::Hash};
 use tokio::time::sleep;
 use tokio::time::Duration;
-
 pub type InActiveMemtableID = Vec<u8>;
 pub type InActiveMemtable = Arc<RwLock<InMemoryTable<Vec<u8>>>>;
 pub type FlushDataMemTable = (InActiveMemtableID, InActiveMemtable);
@@ -41,27 +43,36 @@ pub enum FlushResponse {
 }
 
 #[derive(Debug, Clone)]
-pub struct Flusher {
+pub struct Flusher<K>
+where
+    K: Hash + PartialOrd + Ord + Send + Sync,
+{
+    pub(crate) read_only_memtable: ExcRwAcc<IndexMap<K, Arc<RwLock<InMemoryTable<K>>>>>,
     pub(crate) table_to_flush: Arc<RwLock<InMemoryTable<Vec<u8>>>>,
     pub(crate) table_id: Vec<u8>,
-    pub(crate) bucket_map: BucketMap,
-    pub(crate) bloom_filters: Vec<BloomFilter>,
-    pub(crate) biggest_key_index: TableBiggestKeys,
+    pub(crate) bucket_map: ExcRwAcc<BucketMap>,
+    pub(crate) bloom_filters: ExcRwAcc<Vec<BloomFilter>>,
+    pub(crate) biggest_key_index: ExcRwAcc<TableBiggestKeys>,
     pub(crate) use_ttl: bool,
     pub(crate) entry_ttl: u64,
 }
 
-impl Flusher {
+impl<K> Flusher<K>
+where
+    K: Hash + PartialOrd + Ord + Send + Sync + 'static + Borrow<std::vec::Vec<u8>>,
+{
     pub fn new(
+        read_only_memtable: ExcRwAcc<IndexMap<K, Arc<RwLock<InMemoryTable<K>>>>>,
         table_to_flush: Arc<RwLock<InMemoryTable<Vec<u8>>>>,
         table_id: Vec<u8>,
-        bucket_map: BucketMap,
-        bloom_filters: Vec<BloomFilter>,
-        biggest_key_index: TableBiggestKeys,
+        bucket_map: ExcRwAcc<BucketMap>,
+        bloom_filters: ExcRwAcc<Vec<BloomFilter>>,
+        biggest_key_index: ExcRwAcc<TableBiggestKeys>,
         use_ttl: bool,
         entry_ttl: u64,
     ) -> Self {
         Self {
+            read_only_memtable,
             table_to_flush,
             table_id,
             bucket_map,
@@ -72,7 +83,7 @@ impl Flusher {
         }
     }
 
-    pub async fn flush(&mut self) -> Result<FlushResponse, StorageEngineError> {
+    pub async fn flush(&mut self) -> Result<(), StorageEngineError> {
         let flush_data = self;
         let table = Arc::clone(&flush_data.table_to_flush);
         let table_id = &flush_data.table_id;
@@ -89,21 +100,29 @@ impl Flusher {
         let hotness = 1;
         let sstable_path = flush_data
             .bucket_map
+            .write()
+            .await
             .insert_to_appropriate_bucket(&table.read().await.to_owned(), hotness)
             .await?;
 
         let data_file_path = sstable_path.get_data_file_path().clone();
         table_bloom_filter.set_sstable_path(sstable_path);
-        flush_data.bloom_filters.push(table_bloom_filter.to_owned());
+        flush_data
+            .bloom_filters
+            .write()
+            .await
+            .push(table_bloom_filter.to_owned());
 
         // sort bloom filter by hotness
-        flush_data.bloom_filters.sort_by(|a, b| {
+        flush_data.bloom_filters.write().await.sort_by(|a, b| {
             b.get_sstable_path()
                 .get_hotness()
                 .cmp(&a.get_sstable_path().get_hotness())
         });
         flush_data
             .biggest_key_index
+            .write()
+            .await
             .set(data_file_path, table_biggest_key);
         let mut should_compact = false;
         //check for compaction conditions before returning
@@ -124,81 +143,51 @@ impl Flusher {
         //             &mut flush_data.biggest_key_index,
         //         )
         //         .await?;
-        //     return Ok(FlushResponse::Success {
-        //         table_id: table_id.to_vec(),
-        //         updated_bucket_map: flush_data.bucket_map.to_owned(),
-        //         updated_bloom_filters: flush_data.bloom_filters.to_owned(),
-        //         updated_biggest_key_index: flush_data.biggest_key_index.to_owned(),
-        //     });
         // }
-
-        return Ok(FlushResponse::Success {
-            table_id: table_id.to_vec(),
-            updated_bucket_map: flush_data.bucket_map.to_owned(),
-            updated_bloom_filters: flush_data.bloom_filters.to_owned(),
-            updated_biggest_key_index: flush_data.biggest_key_index.to_owned(),
-        });
+        Ok(())
     }
 
     pub fn flush_data_collector(
         &self,
         rcx: Arc<RwLock<Receiver<FlushDataMemTable>>>,
         sdx: Arc<RwLock<Sender<Result<FlushUpdateMsg, StorageEngineError>>>>,
-        buckets: BucketMap,
-        bloom_filters: Vec<BloomFilter>,
-        biggest_key_index: TableBiggestKeys,
+        buckets: ExcRwAcc<BucketMap>,
+        bloom_filters: ExcRwAcc<Vec<BloomFilter>>,
+        biggest_key_index: ExcRwAcc<TableBiggestKeys>,
+        read_only_memtable: ExcRwAcc<IndexMap<K, Arc<RwLock<InMemoryTable<K>>>>>,
         config: Config,
     ) {
         let rcx_clone = Arc::clone(&rcx);
         let sdx_clone = Arc::clone(&sdx);
 
         spawn(async move {
-            let mut current_buckets = buckets;
-            let mut current_bloom_filters = bloom_filters;
-            let mut current_biggest_key_index = biggest_key_index;
-
+            let current_buckets = Arc::clone(&buckets);
+            let current_bloom_filters = Arc::clone(&bloom_filters);
+            let current_biggest_key_index = Arc::clone(&biggest_key_index);
+            let current_read_only_memtables = Arc::clone(&read_only_memtable);
             while let Some((table_id, table_to_flush)) = rcx_clone.write().await.recv().await {
-                println!("Flushing started");
-                let mut flusher = Flusher::new(
+                let mut flusher = Flusher::<K>::new(
+                    Arc::clone(&read_only_memtable),
                     table_to_flush,
-                    table_id,
-                    current_buckets.clone(),
-                    current_bloom_filters.clone(),
-                    current_biggest_key_index.clone(),
+                    table_id.to_owned(),
+                    Arc::clone(&current_buckets),
+                    Arc::clone(&current_bloom_filters),
+                    Arc::clone(&current_biggest_key_index),
                     config.enable_ttl,
                     config.entry_ttl_millis,
                 );
 
                 match flusher.flush().await {
-                    Ok(flush_res) => match flush_res {
-                        FlushResponse::Success {
-                            table_id,
-                            updated_bucket_map,
-                            updated_bloom_filters,
-                            updated_biggest_key_index,
-                        } => {
-                            current_buckets = updated_bucket_map;
-                            current_bloom_filters = updated_bloom_filters;
-                            current_biggest_key_index = updated_biggest_key_index;
-
-                            let _ = sdx_clone
-                                .write()
-                                .await
-                                .send(Ok(FlushUpdateMsg {
-                                    flushed_memtable_id: table_id,
-                                    buckets: current_buckets.to_owned(),
-                                    bloom_filters: current_bloom_filters.to_owned(),
-                                    biggest_key_index: current_biggest_key_index.to_owned(),
-                                }))
-                                .await;
-                            // Sleep for 200 seconds
-                            //sleep(Duration::from_secs(1)).await;
-                        }
-                        FlushResponse::Failed { reason } => {
-                            println!("Flush failed: {}", reason);
-                            // Handle failure case here
-                        }
-                    },
+                    Ok(_) => {
+                        current_read_only_memtables
+                            .write()
+                            .await
+                            .shift_remove(&table_id);
+                        println!("Fix is successful")
+                        // Sleep for 200 seconds
+                        //sleep(Duration::from_secs(1)).await;
+                    }
+                    // Handle failure case here
                     Err(err) => {
                         println!("Flush error: {}", err);
                         // Handle error here

--- a/src/flusher/flusher.rs
+++ b/src/flusher/flusher.rs
@@ -180,15 +180,19 @@ impl Flusher {
                             current_buckets = updated_bucket_map;
                             current_bloom_filters = updated_bloom_filters;
                             current_biggest_key_index = updated_biggest_key_index;
-                            println!("sent update message");
-                            let _ = sdx_clone.write().await.send(Ok(FlushUpdateMsg {
-                                flushed_memtable_id: table_id,
-                                buckets: current_buckets.to_owned(),
-                                bloom_filters: current_bloom_filters.to_owned(),
-                                biggest_key_index: current_biggest_key_index.to_owned(),
-                            }));
+
+                            let _ = sdx_clone
+                                .write()
+                                .await
+                                .send(Ok(FlushUpdateMsg {
+                                    flushed_memtable_id: table_id,
+                                    buckets: current_buckets.to_owned(),
+                                    bloom_filters: current_bloom_filters.to_owned(),
+                                    biggest_key_index: current_biggest_key_index.to_owned(),
+                                }))
+                                .await;
                             // Sleep for 200 seconds
-                            //sleep(Duration::from_secs(10)).await;
+                            //sleep(Duration::from_secs(1)).await;
                         }
                         FlushResponse::Failed { reason } => {
                             println!("Flush failed: {}", reason);

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -1,4 +1,4 @@
 mod storage;
 pub use storage::SizeUnit;
 pub use storage::StorageEngine;
-pub use storage::ExcRwAcc;
+pub use storage::ExRW;

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -1,3 +1,4 @@
 mod storage;
 pub use storage::SizeUnit;
 pub use storage::StorageEngine;
+pub use storage::ExcRwAcc;

--- a/src/storage_engine/storage.rs
+++ b/src/storage_engine/storage.rs
@@ -212,16 +212,17 @@ impl StorageEngine<Vec<u8>> {
             created_at,
             is_tombstone,
         );
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
-        // println!("========================================={}===================================", self.read_only_memtables.iter().len());
+
         self.active_memtable.insert(&entry)?;
         //println!("read");
-        //println!("Write proccessed!, all I need to know is that even 1 billion writes can be accepted and the whole flush and compaction can happen in background without interupting write performance: {}", String::from_utf8_lossy(key));
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("===========================================LENGTH OF TABLES {}====================================================", self.read_only_memtables.iter().len());
+        println!("Write proccessed!, all I need to know is that even 1 billion writes can be accepted and the whole flush and compaction can happen in background without interupting write performance: {}", String::from_utf8_lossy(key));
         Ok(true)
     }
 
@@ -346,14 +347,11 @@ impl StorageEngine<Vec<u8>> {
             ChanRecv::FlushResRecv(response) => match response.try_recv() {
                 Ok(channel_response) => match channel_response {
                     Ok(flush_updated_msg) => {
-                        println!("UPDATE RECIEVED");
-
                         self.bloom_filters = flush_updated_msg.bloom_filters;
                         self.buckets = flush_updated_msg.buckets;
                         self.biggest_key_index = flush_updated_msg.biggest_key_index;
-                       let removed_value = self.read_only_memtables
+                        self.read_only_memtables
                             .shift_remove(&flush_updated_msg.flushed_memtable_id);
-                        println!("============================{:?}======================", removed_value);
                     }
                     Err(err) => println!("Receiever error {:?}", err),
                 },
@@ -967,7 +965,7 @@ mod tests {
                 // println!("Checking for update");
                 sgg.write().await.check_queued_updates().await;
                 // println!("We are here");
-                
+
                 sleep(Duration::from_secs(2)).await;
             }
         });
@@ -980,7 +978,6 @@ mod tests {
                 let resp = value.put(&k, "boy").await;
                 match resp {
                     Ok(v) => {
-                        println!("still writing");
                         assert_eq!(v, true)
                     }
                     Err(_) => {
@@ -1007,7 +1004,7 @@ mod tests {
             }
         }
 
-        sleep(Duration::from_secs(400)).await;
+        //sleep(Duration::from_secs(400)).await;
 
         // let s_engine = Arc::clone(&sg);
 


### PR DESCRIPTION
**Flush now has exclusive RwLock access to In-memory structures**

The flush operation now has exclusive access to in-memory buckets, bloom filters, and the biggest key index. This is done so that we can immediately update these values instead of sending the updated values through a channel and having a listener who frequently listens to flush updates.
 
This implementation is better because we don't need an infinite loop to constantly poll updates from the receiving channel and then update in-memory structures. the infinite loop can overconsume the CPU and from the previous implementation, we need to have a write lock on the storage engine during this check which prevents reads(too expensive). 

Option 2 is kept in a separate branch in case we discover the thread contention gets too high while doing the benchmarking test